### PR TITLE
Add MoP support, introduce VP.isMop variable

### DIFF
--- a/Compat.lua
+++ b/Compat.lua
@@ -1,6 +1,6 @@
 local VP = VendorPrice
 
-if not VP.isVanilla and not VP.isCata then
+if not VP.isVanilla and not VP.isCata and not VP.isMop then
 	return
 end
 

--- a/VendorPrice.lua
+++ b/VendorPrice.lua
@@ -3,8 +3,9 @@ local VP = VendorPrice
 
 VP.isVanilla = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
 VP.isCata = WOW_PROJECT_ID == WOW_PROJECT_CATACLYSM_CLASSIC
+VP.isMop = WOW_PROJECT_ID == WOW_PROJECT_MISTS_CLASSIC
 
-if not VP.isVanilla and not VP.isCata then
+if not VP.isVanilla and not VP.isCata and not VP.isMop then
 	return
 end
 
@@ -76,7 +77,7 @@ function VP:SetPrice(tt, hasCataTooltip, source, count, item, isOnTooltipSetItem
 				local displayPrice = isShift and sellPrice or sellPrice * count
 				if self.isVanilla then
 					SetTooltipMoney(tt, displayPrice, nil, SELL_PRICE_TEXT)
-				elseif self.isCata then
+				elseif self.isCata or self.isMop then
 					if hasCataTooltip then
 						if isShift then
 							overridePrice = displayPrice

--- a/VendorPrice.toc
+++ b/VendorPrice.toc
@@ -1,4 +1,4 @@
-## Interface: 11504, 40400
+## Interface: 11504, 40400, 50500
 ## Version: @project-version@
 ## Title: Vendor Price
 ## Notes: Displays the price of an item when not at a vendor


### PR DESCRIPTION
I saw you mentioning on the CurseForge detail page that you need to find time to update the addon to support MoP.

I did my best to match your current style in my updates to make that happen for you. I will leave it up to your discretion to decide whether you want to go ahead with the pull request, or whether you'd prefer to implement it yourself.

**Changes explained**:

1. I am introducing a variable of a similar nature to existing `VP.isCata`, calling it `VP.isMop`
2. `VP.isMop` evaluates to `true`, when built-in constant `WOW_PROJECT_ID` equals to `WOW_PROJECT_MISTS_CLASSIC` (I referenced [this as source of truth](https://warcraft.wiki.gg/wiki/WOW_PROJECT_ID), and then checked what value it evaluates in-game with `/run print(WOW_PROJECT_MISTS_CLASSIC)`. It is number `19`.
3. I added supported interface version `50500`, which I obtained via `/run print((select(4, GetBuildInfo())))`
4. In the VendorPrice.lua:80, you were checking `VP.isCata` to be true, which I extended to still evaluate to true if either version is Cata or MoP. I assume this is due to Cata providing some form of Vendor Price out of the box, and WoW does this going forward with future versions.

Thank you for all the hard work you've put into developing this addon long time ago, I've been a user since (late?) classic vanilla. 

I have opted to not modify the list of authors it `.toc` file, as I am not adding anything of substance, but not opposed to you including me should you decide to. 
